### PR TITLE
Create a new attachment when the picking is confirmed.

### DIFF
--- a/models/delivery_carrier.py
+++ b/models/delivery_carrier.py
@@ -144,7 +144,7 @@ class DeliveryCarrier(models.Model):
             })
             try:
                 # Pre generate the label
-                picking.ensure_radish_label_attachment()
+                picking._create_radish_label_attachment()
             except Exception as e:
                 _logger.exception(e)              
 


### PR DESCRIPTION
Create a new attachment when the picking is confirmed. This way, if we cancel the delivery, modify the delivery partner, then re-validate the picking : the new delivery information will be used.