### PR TITLE
Si le champ phone ou email est vide, utiliser la valeur du parent

### DIFF
--- a/api/models/radish_recipient.py
+++ b/api/models/radish_recipient.py
@@ -1,5 +1,6 @@
 from .radish_object import RadishObject
 
+
 class RadishRecipient(RadishObject):
     def __init__(
             self,
@@ -11,14 +12,23 @@ class RadishRecipient(RadishObject):
         self.first = picking_partner.name or picking_partner.commercial_company_name or ''
         self.last = ''
         self.company = picking_partner.commercial_company_name
-        self.phone = picking_partner.phone
-        self.email = picking_partner.email
+
+        current_partner = picking_partner
+        self.phone = current_partner.phone
+        self.email = current_partner.email
+        while current_partner and (not self.phone or not self.email):
+            if not self.phone:
+                self.phone = current_partner.phone
+            if not self.email:
+                self.email = current_partner.email
+
+            current_partner = current_partner.parent_id
 
     def toJSON(self):
         return {
-            'first': self.first,
-            'last': self.last,
+            'first':   self.first,
+            'last':    self.last,
             'company': self.company,
-            'phone': self.phone,
-            'email': self.email,
+            'phone':   self.phone,
+            'email':   self.email,
         }


### PR DESCRIPTION
Le champ email et phone n'est pas obligatoire dans Odoo sur un contact associé à une livraison.

Afin de maximiser vos chances d'avoir les informations de contact du client, je propose d'utiliser les informations du parent au besoin.